### PR TITLE
Fix OptionsBar hotkeys

### DIFF
--- a/PropAnarchy/PropAnarchyUI.cs
+++ b/PropAnarchy/PropAnarchyUI.cs
@@ -14,7 +14,7 @@ namespace PropAnarchy
 
         public void Awake()
         {
-            _label = GameObject.Find("OptionsBar").GetComponent<UIPanel>().AddUIComponent<UILabel>();
+            _label = GameObject.Find("AdvisorButton").GetComponent<UIMultiStateButton>().AddUIComponent<UILabel>();
             _label.relativePosition += new Vector3(-100, 0 , 0);
         }
 


### PR DESCRIPTION
It took me a while to figure it out. Initially thought that your _label object took over focus, but that wasn't the case. The issue is in "Assembly-CSharp/KeyShortcuts::currentlyVisibleOptionPanel"-property.

```
private UIComponent currentlyVisibleOptionPanel
{
	get
	{
		if (m_currentlyVisibleOptionPanel == null || !m_currentlyVisibleOptionPanel.isVisible)
		{
			foreach (UIComponent component in optionsBar.components)
			{
				if (component.isVisible)
				{
					m_currentlyVisibleOptionPanel = component;
					break;
				}
			}
		}
		return m_currentlyVisibleOptionPanel;
	}
}
```
As you can see, it queries for a visible UIComponent and as your panel is the first visible ui object after startup, it will be cached. Thus the solution is, to change the parent of your lable, which this commit simply does.